### PR TITLE
62 padronizar a palavra utilizada para negar um refund

### DIFF
--- a/Model.Application.API/Controllers/RefundController.cs
+++ b/Model.Application.API/Controllers/RefundController.cs
@@ -65,11 +65,11 @@ namespace Model.Application.API.Controllers
         }
 
         [HttpPost]
-        [Route("/refuse/{id}/{userId}")]
+        [Route("/reject/{id}/{userId}")]
         [Authorize(Roles = Roles.Manager + "," + Roles.Supervisor)]
-        public async Task<IActionResult> RefuseRefund([FromRoute] uint id, [FromRoute] uint userId)
+        public async Task<IActionResult> RejectRefund([FromRoute] uint id, [FromRoute] uint userId)
         {
-            var refund = await _service.RefuseRefund(id, userId, HttpContext.RequestAborted);
+            var refund = await _service.RejectRefund(id, userId, HttpContext.RequestAborted);
             return Ok(refund);
         }
 

--- a/Model.Domain/Interfaces/IRefundService.cs
+++ b/Model.Domain/Interfaces/IRefundService.cs
@@ -12,6 +12,6 @@ namespace Model.Domain.Interfaces
         Task<Refund> CreateRefund(Refund refund, CancellationToken ct);
         Task<IEnumerable<Refund?>> GetAllByStatus(EStatus status, CancellationToken ct);
         Task<Refund> ApproveRefund(uint Id, uint userId, CancellationToken ct);
-        Task<Refund> RefuseRefund(uint Id, uint userId, CancellationToken ct);
+        Task<Refund> RejectRefund(uint Id, uint userId, CancellationToken ct);
     }
 }

--- a/Model.Domain/Interfaces/IRuleService.cs
+++ b/Model.Domain/Interfaces/IRuleService.cs
@@ -12,9 +12,9 @@ namespace Model.Domain.Interfaces
         Task<Rule?> GetById(uint id, CancellationToken ct);
         Task<IEnumerable<Rule?>> GetAll(CancellationToken ct);
         Task<Rule> CreateRule(Rule rule, CancellationToken ct);
-        Task<IEnumerable<Rule?>> GetRulesToReproveAny(CancellationToken ct);
+        Task<IEnumerable<Rule?>> GetRulesToRejectAny(CancellationToken ct);
         Task<IEnumerable<Rule?>> GetRulesToApproveAny(CancellationToken ct);
-        Task<IEnumerable<Rule?>> GetRulesToReproveByCategoryId(uint categoryId, CancellationToken ct);
+        Task<IEnumerable<Rule?>> GetRulesToRejectByCategoryId(uint categoryId, CancellationToken ct);
         Task<IEnumerable<Rule?>> GetRulesToApproveByCategoryId(uint categoryId, CancellationToken ct);
         Task<bool> DeactivateRule(uint Id, CancellationToken ct);
         Task<bool> DeactivateACategorysRules(uint categoryId, CancellationToken ct);

--- a/Model.Service/Services/RefundService.cs
+++ b/Model.Service/Services/RefundService.cs
@@ -109,14 +109,14 @@ namespace Model.Service.Services
 
         private async Task<ProcessRefundResult> ProcessRefund(uint categoryId, decimal value, CancellationToken ct)
         {
-            var rulesThatReproveAny = await _ruleService.GetRulesToRejectAny(ct);
+            var rulesThatRejectAny = await _ruleService.GetRulesToRejectAny(ct);
 
-            Rule? reproveAnyResult = GetFirstMatchingRule(rulesThatReproveAny, value);
+            Rule? rejectAnyResult = GetFirstMatchingRule(rulesThatRejectAny, value);
 
-            if (reproveAnyResult is not null)
+            if (rejectAnyResult is not null)
                 return new ProcessRefundResult() { 
                     Status = EStatus.Rejected, 
-                    Rule = reproveAnyResult
+                    Rule = rejectAnyResult
                 };
 
 
@@ -131,16 +131,16 @@ namespace Model.Service.Services
                     Rule = approveAnyResult
                 };
 
-            var rulesThatReproveByCategory = await _ruleService
+            var rulesThatRejectByCategory = await _ruleService
                .GetRulesToRejectByCategoryId(categoryId, ct);
 
-            Rule? reproveByCategoryResult = GetFirstMatchingRule(rulesThatReproveByCategory, value);
+            Rule? rejectByCategoryResult = GetFirstMatchingRule(rulesThatRejectByCategory, value);
 
-            if (reproveByCategoryResult is not null)
+            if (rejectByCategoryResult is not null)
                 return new ProcessRefundResult()
                 {
                     Status = EStatus.Approved,
-                    Rule = reproveByCategoryResult
+                    Rule = rejectByCategoryResult
                 };
 
 

--- a/Model.Service/Services/RefundService.cs
+++ b/Model.Service/Services/RefundService.cs
@@ -83,7 +83,7 @@ namespace Model.Service.Services
             return refund;
         }
 
-        public async Task<Refund> RefuseRefund(uint Id, uint userId, CancellationToken ct)
+        public async Task<Refund> RejectRefund(uint Id, uint userId, CancellationToken ct)
         {
             var refund = await _repository.GetById(Id, ct);
 
@@ -109,7 +109,7 @@ namespace Model.Service.Services
 
         private async Task<ProcessRefundResult> ProcessRefund(uint categoryId, decimal value, CancellationToken ct)
         {
-            var rulesThatReproveAny = await _ruleService.GetRulesToReproveAny(ct);
+            var rulesThatReproveAny = await _ruleService.GetRulesToRejectAny(ct);
 
             Rule? reproveAnyResult = GetFirstMatchingRule(rulesThatReproveAny, value);
 
@@ -132,7 +132,7 @@ namespace Model.Service.Services
                 };
 
             var rulesThatReproveByCategory = await _ruleService
-               .GetRulesToReproveByCategoryId(categoryId, ct);
+               .GetRulesToRejectByCategoryId(categoryId, ct);
 
             Rule? reproveByCategoryResult = GetFirstMatchingRule(rulesThatReproveByCategory, value);
 

--- a/Model.Service/Services/RuleService.cs
+++ b/Model.Service/Services/RuleService.cs
@@ -84,7 +84,7 @@ namespace Model.Service.Services
             return list;
         }
 
-        public async Task<IEnumerable<Rule?>> GetRulesToReproveByCategoryId(uint categoryId, CancellationToken ct)
+        public async Task<IEnumerable<Rule?>> GetRulesToRejectByCategoryId(uint categoryId, CancellationToken ct)
         {
             var list = await _repository.GetByParameter(ct, x => x.Category.Id == categoryId 
                 && x.IsActive && !x.Action);
@@ -98,7 +98,7 @@ namespace Model.Service.Services
             return list;
         }
 
-        public async Task<IEnumerable<Rule?>> GetRulesToReproveAny(CancellationToken ct)
+        public async Task<IEnumerable<Rule?>> GetRulesToRejectAny(CancellationToken ct)
         {
             var list = await _repository.GetByParameter(ct, x => x.Category.Id == 0 && !x.Action && x.IsActive);
             return list;

--- a/ServicesTests/RefundServiceTests.cs
+++ b/ServicesTests/RefundServiceTests.cs
@@ -47,7 +47,7 @@ namespace ServicesTests
         {
             repository.GetById(Arg.Any<uint>(), ct).Returns(Task.FromResult<Refund?>(null));
 
-            await _sut.Invoking(x => x.RefuseRefund(3, 9, ct))
+            await _sut.Invoking(x => x.RejectRefund(3, 9, ct))
                 .Should().ThrowAsync<ResourceNotFoundException>();            
         }
         [Theory]
@@ -60,7 +60,7 @@ namespace ServicesTests
                     MinValue = 0, MaxValue = 1000, Action = false,
                 }
             };
-            ruleService.GetRulesToReproveAny(ct).Returns(rules);
+            ruleService.GetRulesToRejectAny(ct).Returns(rules);
 
             await _sut.CreateRefund(refund, ct);
 
@@ -111,7 +111,7 @@ namespace ServicesTests
         [MemberData(nameof(AllRefundsAndExpectedStatus))]
         public async Task status_should_be_correct(Refund refund, EStatus expectedStatus)
         {
-            ruleService.GetRulesToReproveAny(ct).Returns(ListOfRuleToRejectAny());
+            ruleService.GetRulesToRejectAny(ct).Returns(ListOfRuleToRejectAny());
 
             ruleService.GetRulesToApproveAny(ct).Returns(ListOfRuleToApproveAny());
 

--- a/ServicesTests/RefundServiceTests.cs
+++ b/ServicesTests/RefundServiceTests.cs
@@ -43,7 +43,7 @@ namespace ServicesTests
         }
         
         [Fact]
-        public async Task refuse_refund_must_throw_an_exception_when_refund_could_not_be_found()
+        public async Task reject_refund_must_throw_an_exception_when_refund_could_not_be_found()
         {
             repository.GetById(Arg.Any<uint>(), ct).Returns(Task.FromResult<Refund?>(null));
 


### PR DESCRIPTION
All denial words for a refund in both method names and body code or strings have been defaulted to "reject"